### PR TITLE
docs: translate CLAUDE.md to English, drop unreliable downloads badge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,118 +1,118 @@
 # CLAUDE.md
 
-Guida operativa per chi sviluppa su questo repository.
+Operational guide for anyone developing on this repository.
 
-## Cos'è
+## What it is
 
-Directus endpoint extension che espone Swagger UI (`/api-docs`) e OpenAPI (`/api-docs/oas`) mergiando lo spec core di Directus con le definizioni custom delle altre extension. Le definizioni custom possono essere dichiarate in due modi, supportati nello stesso progetto:
+Directus endpoint extension that exposes Swagger UI (`/api-docs`) and OpenAPI (`/api-docs/oas`) by merging the Directus core spec with custom definitions from other extensions. Custom definitions can be declared in two ways, both supported in the same project:
 
-1. **YAML** — `oasconfig.yaml` + `oas.yaml` per extension; validazione runtime opzionale tramite `validate(router, services, schema, paths?)` che monta `express-openapi-validator`.
-2. **Zod** — `defineEndpoint(id, (route, ctx) => { route({...}) })` è l'API ergonomica: deriva il prefix OpenAPI da `id`, espone `services`/`getSchema` nello scope e wrappa internamente il `defineEndpoint` del SDK. `defineRoute(router, {...})` resta come API low-level per casi misti Zod+Express raw. Tutto esposto come named export del main, accanto a `validate`: `import { defineEndpoint, defineRoute, registerSchema, z } from 'directus-extension-api-docs'`.
+1. **YAML** — `oasconfig.yaml` + `oas.yaml` per extension; optional runtime validation via `validate(router, services, schema, paths?)`, which mounts `express-openapi-validator`.
+2. **Zod** — `defineEndpoint(id, (route, ctx) => { route({...}) })` is the ergonomic API: it derives the OpenAPI prefix from `id`, exposes `services`/`getSchema` in scope, and internally wraps the SDK's own `defineEndpoint`. `defineRoute(router, {...})` remains as the low-level API for mixed Zod+raw Express cases. Everything is exposed as a named export of the main entry point, alongside `validate`: `import { defineEndpoint, defineRoute, registerSchema, z } from 'directus-extension-api-docs'`.
 
-Le due strade si fondono in `src/index.ts`, route handler `GET /oas`: core spec → merge YAML (`config.paths/tags/components`) → merge `buildZodOasFragment()` → eventuale `filterPaths(publishedTags)`.
+The two paths merge in `src/index.ts`, in the `GET /oas` route handler: core spec → merge YAML (`config.paths/tags/components`) → merge `buildZodOasFragment()` → optional `filterPaths(publishedTags)`.
 
-## Comandi (sempre `pnpm`)
+## Commands (always `pnpm`)
 
 ```
 pnpm install
 pnpm test         # Jest
-pnpm typecheck    # tsc --noEmit (richiesto per i type-test in tests/zod/types.test-d.ts)
+pnpm typecheck    # tsc --noEmit (required for the type-tests in tests/zod/types.test-d.ts)
 pnpm lint         # eslint
-pnpm build        # directus-extension build → singolo dist/index.js
+pnpm build        # directus-extension build → single dist/index.js
 pnpm dev          # build watch
 ```
 
-`pnpm test`, `pnpm typecheck`, `pnpm lint` devono passare puliti prima di committare.
+`pnpm test`, `pnpm typecheck`, `pnpm lint` must all pass cleanly before committing.
 
-## Architettura sorgenti
+## Source architecture
 
 ```
 src/
-├── index.ts        Entry point Directus. Esporta { id, validate, handler }.
-│                   Handler /oas mergia core + YAML + fragment Zod in quest'ordine.
-├── utils.ts        getConfig (scan YAML), getOas/getOasAll, merge(), filterPaths(), getPackage().
-├── types.ts        Tipi YAML (oasConfig, oas).
-└── zod/            Sotto-modulo: i suoi simboli sono ri-esportati come named exports da src/index.ts.
-    ├── index.ts    Barrel: esegue extendZodWithOpenApi(z); export pubblico.
-    ├── registry.ts Singleton OpenAPIRegistry; registerSchema; _resetRegistry (test only).
-    ├── validate.ts zodValidator middleware: safeParse params→query→body, envelope errori 400.
+├── index.ts        Directus entry point. Exports { id, validate, handler }.
+│                   The /oas handler merges core + YAML + Zod fragment in this order.
+├── utils.ts        getConfig (scans YAML), getOas/getOasAll, merge(), filterPaths(), getPackage().
+├── types.ts        YAML types (oasConfig, oas).
+└── zod/            Sub-module: its symbols are re-exported as named exports from src/index.ts.
+    ├── index.ts    Barrel: runs extendZodWithOpenApi(z); public export.
+    ├── registry.ts OpenAPIRegistry singleton; registerSchema; _resetRegistry (test only).
+    ├── validate.ts zodValidator middleware: safeParse params→query→body, 400 error envelope.
     ├── openapi.ts  buildZodOasFragment(): registry → {paths, components, tags}.
-    ├── route.ts    defineRoute(): registry.registerPath + montaggio middleware su router Express.
-    └── endpoint.ts defineEndpoint(id, setup): wrapper che ritorna {id, handler}, cura prefix `/<id>`,
-                    ed espone `route()` curried su router+prefix dentro lo setup callback.
+    ├── route.ts    defineRoute(): registry.registerPath + mounts middleware on the Express router.
+    └── endpoint.ts defineEndpoint(id, setup): wrapper returning {id, handler}, handles the `/<id>` prefix,
+                    and exposes a curried route() over router+prefix inside the setup callback.
 ```
 
-Riusa `merge()` di `utils.ts` e `filterPaths()` di `utils.ts`. Non reinventare deep-merge o filtro tag.
+Reuse `merge()` and `filterPaths()` from `utils.ts`. Don't reinvent deep-merge or tag filtering.
 
-## Gotcha (cose non ovvie che bruciano tempo)
+## Gotchas (non-obvious things that waste time)
 
-- **Build single-file.** `directus-extension build` (rollup del SDK) bundla `src/index.ts` con tutti gli import locali (incluso `src/zod/*`) in un unico `dist/index.js`. Le dipendenze npm (`zod`, `@asteasolutions/zod-to-openapi`, `swagger-ui-express`, ...) sono richieste a runtime. Non aggiungere step di build separati per emettere `dist/zod/*` — i simboli Zod sono esposti come named exports di `src/index.ts`.
-- **`@directus/extensions-sdk` è ESM.** Jest+ts-jest non lo carica in contesto CommonJS. I test che caricano `src/index.ts` devono mockarlo: `jest.mock('@directus/extensions-sdk', () => ({ defineEndpoint: (h: unknown) => h }))`.
-- **`getConfig()` legge da `process.cwd()` al module-load di `src/index.ts`.** Per testare diverse fixture YAML, montare `jest.spyOn(process, 'cwd')` **prima** del primo `require('../../src/index')`. ESM `import` viene hoistato e rompe l'ordine — usare `require()` esplicito al module level del test.
-- **Singleton `OpenAPIRegistry`.** `registry.definitions` è un **getter** che ritorna un nuovo array `[...parents, ..._definitions]`; mutarlo non resetta lo stato. `_resetRegistry()` muta `_definitions` (campo privato).
-- **Zod versione.** Direct dep `zod ^3.x`. `@directus/extensions-sdk` trascina transitivamente `zod@4` con `.d.cts` che richiedono TS ≥ 5 per essere parsati — devDep TypeScript `^5.x` è obbligatoria. Non passare a `zod` 4 sul proprio: `@asteasolutions/zod-to-openapi` 7.x supporta solo Zod 3.
-- **Envelope errori comune.** Sia `validate()` (via `express-openapi-validator`) sia `zodValidator` rispondono `400 { message, errors:[{path, message, code}] }`. `path` ha forma `/body/field`, `/params/id`, `/query/limit`. Cambiare la shape è breaking — modificare in coppia entrambi i percorsi e i test.
-- **`useAuthentication`.** Quando `false` (default), il handler `/oas` forza `accountability = { admin: true }` indipendentemente da `req.accountability`. Per testare il gate sull'iniezione path custom serve fixture con `useAuthentication: true`.
+- **Single-file build.** `directus-extension build` (an SDK rollup wrapper) bundles `src/index.ts` together with all local imports (including `src/zod/*`) into a single `dist/index.js`. npm dependencies (`zod`, `@asteasolutions/zod-to-openapi`, `swagger-ui-express`, ...) are required at runtime. Don't add a separate build step to emit `dist/zod/*` — the Zod symbols are exposed as named exports of `src/index.ts`.
+- **`@directus/extensions-sdk` is ESM.** Jest+ts-jest can't load it in a CommonJS context. Tests that load `src/index.ts` must mock it: `jest.mock('@directus/extensions-sdk', () => ({ defineEndpoint: (h: unknown) => h }))`.
+- **`getConfig()` reads from `process.cwd()` at module-load time of `src/index.ts`.** To test different YAML fixtures, set up `jest.spyOn(process, 'cwd')` **before** the first `require('../../src/index')`. ESM `import` is hoisted and breaks the ordering — use an explicit module-level `require()` in the test instead.
+- **`OpenAPIRegistry` singleton.** `registry.definitions` is a **getter** that returns a new array (`[...parents, ..._definitions]`); mutating it doesn't reset the state. `_resetRegistry()` mutates the private `_definitions` field.
+- **Zod version.** Direct dep is `zod ^3.x`. `@directus/extensions-sdk` transitively drags in `zod@4` with `.d.cts` files that require TS ≥ 5 to parse — the TypeScript `^5.x` devDependency is mandatory. Don't move to `zod` 4 on your own: `@asteasolutions/zod-to-openapi` 7.x only supports Zod 3.
+- **Shared error envelope.** Both `validate()` (via `express-openapi-validator`) and `zodValidator` respond with `400 { message, errors:[{path, message, code}] }`. `path` has the form `/body/field`, `/params/id`, `/query/limit`. Changing this shape is breaking — update both code paths and their tests together.
+- **`useAuthentication`.** When `false` (default), the `/oas` handler forces `accountability = { admin: true }` regardless of `req.accountability`. To test the gate on custom path injection you need a fixture with `useAuthentication: true`.
 
-## Test
+## Tests
 
 ```
 tests/
-├── index.test.ts             scan YAML, getConfig, merge, filterPaths, bundle support
+├── index.test.ts             YAML scan, getConfig, merge, filterPaths, bundle support
 ├── zod/
 │   ├── registry.test.ts      singleton, .openapi(), reset, complex Zod, extend
 │   ├── validate.test.ts      happy paths, error envelope, coercion
-│   ├── route.test.ts         tutti i verbi (test.each), opzioni, errori sync/async
-│   ├── openapi.test.ts       shape, ogni feature Zod, validazione OAS 3.0
-│   ├── integration.test.ts   merge YAML+Zod, filterPaths su Zod, dedup tag, registry vuoto
-│   └── types.test-d.ts       compile-time (verificato da tsc --noEmit), include @ts-expect-error
+│   ├── route.test.ts         every verb (test.each), options, sync/async errors
+│   ├── openapi.test.ts       shape, every Zod feature, OAS 3.0 validation
+│   ├── integration.test.ts   YAML+Zod merge, filterPaths on Zod, tag dedup, empty registry
+│   └── types.test-d.ts       compile-time (checked by tsc --noEmit), includes @ts-expect-error
 └── legacy/
-    ├── validate.test.ts      regressione express-openapi-validator (body, query, paths arg, envelope)
-    └── oas-handler.test.ts   regressione /oas (merge YAML, info, accountability gate, contributi Zod)
+    ├── validate.test.ts      express-openapi-validator regression (body, query, paths arg, envelope)
+    └── oas-handler.test.ts   /oas regression (YAML merge, info, accountability gate, Zod contributions)
 
 tests/mocks/
-├── oasconfig/, customoas/, merge/, bundle/, mixed/   fixture YAML
-├── zod-mixed/                fixture YAML+Zod per integration.test.ts
-├── legacy-validate/          fixture per tests/legacy/validate.test.ts
-└── legacy-oas/               fixture per tests/legacy/oas-handler.test.ts (useAuthentication: true)
+├── oasconfig/, customoas/, merge/, bundle/, mixed/   YAML fixtures
+├── zod-mixed/                YAML+Zod fixture for integration.test.ts
+├── legacy-validate/          fixture for tests/legacy/validate.test.ts
+└── legacy-oas/               fixture for tests/legacy/oas-handler.test.ts (useAuthentication: true)
 ```
 
-I test usano `supertest` + Express in-process; nessun boot di Directus.
+Tests use `supertest` + an in-process Express app; no Directus boot involved.
 
-## Playground (test runtime in Directus reale)
+## Playground (real Directus runtime testing)
 
 ```
 playground/
-├── docker-compose.yml         Directus 11 + SQLite, bind-mount del dist/ del repo
+├── docker-compose.yml         Directus 11 + SQLite, bind-mounts the repo's dist/
 ├── .gitignore
-└── extensions/                Mappato su /directus/extensions
-    ├── oasconfig.yaml         Config YAML root + securitySchemes per il lock in Swagger
+└── extensions/                Mapped to /directus/extensions
+    ├── oasconfig.yaml         Root YAML config + securitySchemes for the Swagger lock
     ├── yaml-demo/             POST /echo, GET /users/:id (path param + 200/404), DELETE /items/:id
     │   ├── package.json
     │   ├── index.js
     │   └── oas.yaml
-    ├── zod-demo/              8 rotte: GET/POST/PUT/DELETE, discriminatedUnion, security, deprecated, throw
+    ├── zod-demo/              8 routes: GET/POST/PUT/DELETE, discriminatedUnion, security, deprecated, throw
     │   ├── package.json
     │   └── index.js
-    └── directus-services-demo/  Rotte Zod che chiamano UsersService (DB SQLite reale)
+    └── directus-services-demo/  Zod routes calling UsersService (real SQLite DB)
         ├── package.json
         └── index.js
 ```
 
-Uso (dalla root del repo):
+Usage (from the repo root):
 ```
-pnpm build                                              # produce dist/index.js
-docker compose -f playground/docker-compose.yml up      # boot Directus su :8055
+pnpm build                                              # produces dist/index.js
+docker compose -f playground/docker-compose.yml up      # boots Directus on :8055
 ```
 
-L'image è pinnata a `directus/directus:11.17.4` (current stable 11.x — Directus 12 non è ancora rilasciato; 10.x è in ESU).
-Poi `http://localhost:8055/api-docs` (Swagger), `http://localhost:8055/api-docs/oas` (spec), e prova le rotte demo. `EXTENSIONS_AUTO_RELOAD=true` rilegge dist senza restart del container — basta rifare `pnpm build`. Modifiche a `playground/extensions/*/index.js` o `oas.yaml` non richiedono build, vengono prese al volo.
+The image is pinned to `directus/directus:11.17.4` (current stable 11.x — Directus 12 hasn't been released yet; 10.x is in ESU).
+Then visit `http://localhost:8055/api-docs` (Swagger), `http://localhost:8055/api-docs/oas` (spec), and try the demo routes. `EXTENSIONS_AUTO_RELOAD=true` picks up dist changes without restarting the container — just re-run `pnpm build`. Changes to `playground/extensions/*/index.js` or `oas.yaml` don't need a build, they're picked up on the fly.
 
-I demo importano `directus-extension-api-docs` via il bind-mount di `package.json` + `dist/` su `extensions/node_modules/directus-extension-api-docs/` dentro il container; nessun `npm install` lato playground è necessario.
+The demos import `directus-extension-api-docs` via the bind-mount of `package.json` + `dist/` into `extensions/node_modules/directus-extension-api-docs/` inside the container; no `npm install` is needed on the playground side.
 
-## Convenzioni
+## Conventions
 
-- Niente nuovi file Markdown a meno che esplicitamente richiesto.
-- Aggiornamenti al README in modo misurato: la sezione "Zod-first routes (optional)" sta in fondo, non sostituisce niente, non marca YAML come deprecato.
-- `noUnusedLocals` / `noUncheckedIndexedAccess` attivi in tsconfig: usare `?.`, `??`, e prefisso `_` per parametri non usati.
-- Commit message: stile esistente del repo (`feat:`, `fix:`, `docs:`, ...).
+- No new Markdown files unless explicitly requested.
+- Update the README in a measured way: the "Zod-first routes (optional)" section stays at the bottom, doesn't replace anything, and doesn't mark YAML as deprecated.
+- `noUnusedLocals` / `noUncheckedIndexedAccess` are enabled in tsconfig: use `?.`, `??`, and the `_` prefix for unused parameters.
+- Commit messages: follow the repo's existing style (`feat:`, `fix:`, `docs:`, ...).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # directus-extension-api-docs
 
 [![npm version](https://img.shields.io/npm/v/directus-extension-api-docs.svg)](https://www.npmjs.com/package/directus-extension-api-docs)
-[![npm downloads](https://img.shields.io/npm/dm/directus-extension-api-docs.svg)](https://www.npmjs.com/package/directus-extension-api-docs)
 [![license](https://img.shields.io/npm/l/directus-extension-api-docs.svg)](./LICENSE)
 
 > Compatible with Directus `^9 || ^10 || ^11` and both bundled and non-bundled endpoint extensions.


### PR DESCRIPTION
## Summary
- Translate CLAUDE.md to English
- Remove npm downloads badge from README (shields.io dm/dt intermittently fails with "rate limited by upstream service" on GitHub); version and license badges kept as they're static manifest data

https://claude.ai/code/session_011gt2VgZQ4QVKagUoooaVRk